### PR TITLE
Updated Chroma.Shine

### DIFF
--- a/Chroma.Shine/Chroma.Shine.csproj
+++ b/Chroma.Shine/Chroma.Shine.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Chroma</RootNamespace>
 
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <LangVersion>11</LangVersion>
+        <LangVersion>10</LangVersion>
     </PropertyGroup>
     
     <ItemGroup>

--- a/Chroma.Shine/Chroma.Shine.csproj
+++ b/Chroma.Shine/Chroma.Shine.csproj
@@ -1,14 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <RootNamespace>Chroma</RootNamespace>
 
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <LangVersion>11</LangVersion>
     </PropertyGroup>
     
     <ItemGroup>
-      <PackageReference Include="Chroma" Version="0.17.1" />
+      <PackageReference Include="Chroma" Version="0.58.0" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -18,7 +19,7 @@
         <Version>0.1.0</Version>
         <Author>Ciastex</Author>
         <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/Ciastex/Chroma.Shine</RepositoryUrl>
+        <RepositoryUrl>https://github.com/Chroma-2D/Chroma.Shine</RepositoryUrl>
         <PackageTags>gamedev;engine;2d;chroma;framework;sdl;opengl;game;xna;netcore</PackageTags>
     </PropertyGroup>
 </Project>

--- a/Chroma.Shine/Graphics/Sprite.cs
+++ b/Chroma.Shine/Graphics/Sprite.cs
@@ -36,8 +36,8 @@ namespace Chroma.Graphics
         {
             if (Shearing != Vector2.Zero)
             {
-                context.Transform.Push();
-                context.Transform.Shear(Shearing);
+                RenderTransform.Push();
+                RenderTransform.Shear(Shearing);
             }
 
             context.DrawTexture(
@@ -50,7 +50,7 @@ namespace Chroma.Graphics
 
             if (Shearing != Vector2.Zero)
             {
-                context.Transform.Pop();
+                RenderTransform.Shear(Shearing);
             }
         }
 

--- a/Chroma.Shine/Graphics/SpriteSheet.cs
+++ b/Chroma.Shine/Graphics/SpriteSheet.cs
@@ -48,15 +48,15 @@ namespace Chroma.Graphics
         {
             if (Shearing != Vector2.Zero)
             {
-                context.Transform.Push();
-                context.Transform.Shear(Shearing);
+                RenderTransform.Push();
+                RenderTransform.Shear(Shearing);
             }
 
             context.DrawTexture(Texture, Position, Scale, Origin, Rotation, _sourceRectangles[CurrentFrame]);
 
             if (Shearing != Vector2.Zero)
             {
-                context.Transform.Pop();
+                RenderTransform.Pop();
             }
         }
 

--- a/Chroma.ShineExample/Chroma.ShineExample.csproj
+++ b/Chroma.ShineExample/Chroma.ShineExample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8.0</LangVersion>
+        <TargetFramework>net7.0</TargetFramework>
+        <LangVersion>11</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -10,6 +10,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Chroma" Version="0.17.1" />
+      <PackageReference Include="Chroma" Version="0.58.0" />
     </ItemGroup>
 </Project>

--- a/Chroma.ShineExample/Chroma.ShineExample.csproj
+++ b/Chroma.ShineExample/Chroma.ShineExample.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
-        <LangVersion>11</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Chroma.ShineExample/GameCore.cs
+++ b/Chroma.ShineExample/GameCore.cs
@@ -1,7 +1,7 @@
 using System.Numerics;
 using Chroma.Diagnostics.Logging;
 using Chroma.Graphics;
-using Chroma.Input.EventArgs;
+using Chroma.Input;
 using Chroma.Physics;
 
 namespace Chroma.ShineExample
@@ -16,7 +16,7 @@ namespace Chroma.ShineExample
         private Entity _e4;
 
         internal GameCore()
-            : base(false)
+            : base(new(false, false))
         {
             _e1 = new Entity {Position = new Vector2(120, 120)};
             _e1.AttachCollider(new RectangleCollider(_e1, 32, 32) {Tag = "_e1"});


### PR DESCRIPTION
Updated Chroma.Shine and its examples to use C# 10.0, .NET 6 and Chroma 0.58.0